### PR TITLE
spartialsortperm!!: partial sort perm function for sorting "top"-`k` of `n` with `k<=n`

### DIFF
--- a/src/SimultaneousSortperm.jl
+++ b/src/SimultaneousSortperm.jl
@@ -10,7 +10,8 @@ using Base.Order
 using Base: copymutable, uinttype, sub_with_overflow, add_with_overflow
 
 export ssortperm!!, ssortperm!, ssortperm
-export spartialsortperm!!, spartialsortperm!, spartialsortperm, sselect!!
+# export spartialsortperm!!, spartialsortperm!, spartialsortperm, sselect!!
+export spartialsortperm!!, sselect!! # spartialsortperm!, spartialsortperm
 
 const SSORTPERM_INPLACE_SMALL_THRESHOLD = 40
 const SSORTPERM_SMALL_THRESHOLD = 80
@@ -694,7 +695,7 @@ function spartialsortperm!!(
     1 <= k <= length(v) || throw(ArgumentError("k must satisfy 1 <= k <= length(v)"))
     ix .= LinearIndices(v)
     vs = StructArray{Tuple{eltype(v), eltype(ix)}}(val=v, ix=ix)
-    o = ord(lt, by, rev ? true : nothing, order)
+    o = ord(lt, x -> by(x[1]), rev ? true : nothing, order)
     offsets_l = MVector{PDQ_BLOCK_SIZE, Int}(undef)
     offsets_r = MVector{PDQ_BLOCK_SIZE, Int}(undef)
     a = BranchlessPatternDefeatingQuicksortAlg()
@@ -704,6 +705,7 @@ function spartialsortperm!!(
     return ix[1:k]
 end
 
+#=
 """
     spartialsortperm!(
         ix::AbstractVector{Int}, v::AbstractVector, k::Integer;
@@ -722,13 +724,14 @@ function spartialsortperm!(
     1 <= k <= length(v) || throw(ArgumentError("k must satisfy 1 <= k <= length(v)"))
     ix .= LinearIndices(v)
     vs = StructArray{Tuple{eltype(v), eltype(ix)}}(val=v, ix=ix)
-    o = ord(lt, by, rev ? true : nothing, order)
+    o = ord(lt, x -> by(x[1]), rev ? true : nothing, order)
     offsets_l = MVector{PDQ_BLOCK_SIZE, Int}(undef)
     offsets_r = MVector{PDQ_BLOCK_SIZE, Int}(undef)
     a = BranchlessPatternDefeatingQuicksortAlg()
     sselect!!(vs, firstindex(vs), lastindex(vs), k, a, o, offsets_l, offsets_r)
     # Now sort the first k indices
-    sort!(ix, 1, k, InsertionSort, Base.Order.By(i -> v[i], o))
+    # sort!(ix, 1, k, InsertionSort, Base.Order.By(i -> v[i], o))
+    _sortperm_inplace_small_optimization!(ix, v, vs, 1, k, o::Ordering)
     return ix[1:k]
 end
 
@@ -747,6 +750,7 @@ function spartialsortperm(
     ix = allocate_index_vector(v)
     spartialsortperm!(ix, v, k; lt=lt, by=by, rev=rev, order=order)
 end
+=#
 
 """
     sselect!!(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,7 @@ function randn_with_nans(n,p)
     return v
 end
 
-println("testing")
-# @testset "SimultaneousSortperm.jl" begin
+@testset "SimultaneousSortperm.jl" begin
     for n in [(0:33)..., 100, 999, 1000, 1001]
         for T in [UInt16, Int, Float64], rev in [false, true], lt in [isless, >]
             for order in [Base.Order.Forward, Base.Order.Reverse], by in [identity, x->x÷100]
@@ -56,9 +55,9 @@ println("testing")
 
                 if n>=1
                     for k in max.(Int.(ceil.(n .* [0.01, 0.1, 0.5, 0.9, 0.95])),1)
-                        println("partial")
-                        println("(T,rev,lt,order,by,(n,k)) = ", (T,rev,lt,order,by,(n,k)))
-                        display(v)
+                        # println("partial")
+                        # println("(T,rev,lt,order,by,(n,k)) = ", (T,rev,lt,order,by,(n,k)))
+                        # display(v)
                         v0 = copy(v)
                         v2 = copy(v)
                         pref_k = sortperm(v, lt=lt, by=by, rev=rev, order=order)
@@ -99,7 +98,7 @@ println("testing")
             end
         end
     end
-# end;
+end;
 
 @testset "OffsetArrays" begin
     for n in [(0:33)..., 100, 999, 1000, 1001]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,8 @@ function randn_with_nans(n,p)
     return v
 end
 
-@testset "SimultaneousSortperm.jl" begin
+println("testing")
+# @testset "SimultaneousSortperm.jl" begin
     for n in [(0:33)..., 100, 999, 1000, 1001]
         for T in [UInt16, Int, Float64], rev in [false, true], lt in [isless, >]
             for order in [Base.Order.Forward, Base.Order.Reverse], by in [identity, x->x÷100]
@@ -52,10 +53,53 @@ end
                 elseif !skiptest
                     @test v2 == vref
                 end
+
+                if n>=1
+                    for k in max.(Int.(ceil.(n .* [0.01, 0.1, 0.5, 0.9, 0.95])),1)
+                        println("partial")
+                        println("(T,rev,lt,order,by,(n,k)) = ", (T,rev,lt,order,by,(n,k)))
+                        display(v)
+                        v0 = copy(v)
+                        v2 = copy(v)
+                        pref_k = sortperm(v, lt=lt, by=by, rev=rev, order=order)
+                        vref_k = sort(v, lt=lt, by=by, rev=rev, order=order)
+                        p = zeros(Int, n)
+
+                        #=
+                        v2 = copy(v)
+                        p[1:k] .= spartialsortperm(v2, k, lt=lt, by=by, rev=rev, order=order)
+                        @test by.(v0[p[1:k]]) == by.(v0[pref_k[1:k]])
+                        # p[1:k] == pref_k[1:k] || println((T,rev,lt,order,by,(n,k)))
+                        
+                        v2 = copy(v)
+                        p .= 0
+                        spartialsortperm!(p, v2, k, lt=lt, by=by, rev=rev, order=order)
+                        @test by.(v0[p[1:k]]) == by.(v0[pref_k[1:k]])
+                        # p[1:k] == pref_k[1:k] || println((T,rev,lt,order,by,(n,k)))
+                        if VERSION >= v"1.7"
+                            @test by.(v2[1:k]) == by.(vref_k[1:k]) skip=skiptest
+                        elseif !skiptest
+                            @test by.(v2[1:k]) == by.(vref_k[1:k])
+                        end
+                        =#
+
+                        v2 = copy(v)
+                        p .= 0
+                        spartialsortperm!!(p, v2, k, lt=lt, by=by, rev=rev, order=order)
+                        @test by.(v0[p[1:k]]) == by.(v0[pref_k[1:k]])
+                        if VERSION >= v"1.7"
+                            @test by.(v2[1:k]) == by.(vref_k[1:k]) skip=skiptest
+                        elseif !skiptest
+                            @test by.(v2[1:k]) == by.(vref_k[1:k])
+                        end
+                        p[1:k] == pref_k[1:k] || println((T,rev,lt,order,by,(n,k)))
+                        # v2[1:k] == vref_k[1:k] || println((T,rev,lt,order,by,(n,k)))
+                    end
+                end
             end
         end
     end
-end;
+# end;
 
 @testset "OffsetArrays" begin
     for n in [(0:33)..., 100, 999, 1000, 1001]


### PR DESCRIPTION
Add a function `spartialsortperm!!` that sorts the larges/smallest `k` elements of an `n`-array with `k<=n`. It's idea is to use a function `sselect!!` to do quickselect to find the `k`th element and then calls the existing `SimultaneousSortperm.jl` functionality to obtain the sorted vector and corresponding permutation.

I had a rough go at the `spartialsortperm!` and `spartialsortperm` variants but have commented them out since they are failing the tests.

One thing to note: for the testsets, I only require `by.(v[p[1:k]])==by.(vref[pref[1:k]])` where `v` and `p` are the result of `spartialsortperm!!` and `vref` and `pref` are the result of `Base`'s `sortperm!`, since there may be multiple "optimal" permutations. I noticed that your tests didn't do this before and am curious why you never encountered multiple "optimal" permutations for `by=x->x÷100`? Even after doing the second pass of sorting by index (unless `Base.jl` also does this?)

Related to: https://github.com/LSchwerdt/SimultaneousSortperm.jl/issues/1#issue-2042625469